### PR TITLE
feat(ci): auto-merge Pull app upstream sync PRs when checks pass

### DIFF
--- a/.github/workflows/auto-merge-upstream-sync.yaml
+++ b/.github/workflows/auto-merge-upstream-sync.yaml
@@ -20,20 +20,21 @@ jobs:
       - name: Approve PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr review --approve "${{ github.event.pull_request.number }}"
+          gh pr review --approve "$PR_NUMBER"
 
       - name: Enable auto-merge (merge commit)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         # Re-enabling auto-merge is idempotent for the conflict-resolved
         # case (synchronize after auto-merge was cancelled). Swallow the
         # error only when auto-merge is already active; fail loudly
         # otherwise.
         run: |
-          PR="${{ github.event.pull_request.number }}"
-          gh pr merge --auto --merge "$PR" || {
-            STATE=$(gh pr view "$PR" \
+          gh pr merge --auto --merge "$PR_NUMBER" || {
+            STATE=$(gh pr view "$PR_NUMBER" \
               --json autoMergeRequest \
               --jq '.autoMergeRequest.mergeMethod // empty')
             [ -n "$STATE" ] || exit 1

--- a/.github/workflows/auto-merge-upstream-sync.yaml
+++ b/.github/workflows/auto-merge-upstream-sync.yaml
@@ -1,0 +1,40 @@
+---
+name: Auto-merge upstream sync PRs
+
+"on":
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+
+jobs:
+  auto-merge:
+    # Only act on PRs from the Pull app in the midstream repo.
+    if: |
+      github.repository == 'opendatahub-io/trustyai-service-operator' &&
+      github.actor == 'pull[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve "${{ github.event.pull_request.number }}"
+
+      - name: Enable auto-merge (merge commit)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Re-enabling auto-merge is idempotent for the conflict-resolved
+        # case (synchronize after auto-merge was cancelled). Swallow the
+        # error only when auto-merge is already active; fail loudly
+        # otherwise.
+        run: |
+          PR="${{ github.event.pull_request.number }}"
+          gh pr merge --auto --merge "$PR" || {
+            STATE=$(gh pr view "$PR" \
+              --json autoMergeRequest \
+              --jq '.autoMergeRequest.mergeMethod // empty')
+            [ -n "$STATE" ] || exit 1
+          }


### PR DESCRIPTION
Adds a GitHub Actions workflow (.github/workflows/auto-merge-upstream-sync.yaml) that automatically approves and enables auto-merge for PRs created by the Pull app (`pull[bot]`) targeting main.

When the Pull app syncs commits from `trustyai-explainability:main`, the resulting PR in this repo previously required manual approval and merge. This workflow removes that manual step: it approves the PR and enables GitHub's auto-merge with the merge commit strategy. The actual merge only fires once all required status checks are green.

The workflow handles the full Pull app PR lifecycle:

- Opened/reopened: approve and arm auto-merge on first creation
- Synchronize: re-arm auto-merge if it was previously cancelled (e.g. after a merge conflict was resolved upstream), while tolerating the case where auto-merge is already active

The `pull[bot]` actor check is safe against (GitHub reserves the [bot] suffix for registered GitHub Apps exclusively).

## How Has This Been Tested?

Workflow logic verified manually by inspection. End-to-end behaviour depends on the Pull app creating a new upstream sync PR against main after this workflow is merged — the auto-merge and approval steps can be confirmed at that point from the Actions run log on that PR.

The yamllint CI check passes locally against the new file.

## Merge criteria:

- The commits are squashed in a cohesive manner and have meaningful messages.
- Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated workflow to streamline pull request approval and merging for upstream synchronization tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->