### PR TITLE
feat: integrate with cluster TLS security profile

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,15 +17,23 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
+	"os"
+	"time"
+
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	nemoguardrailsv1alpha1 "github.com/trustyai-explainability/trustyai-service-operator/api/nemo_guardrails/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"os"
 	"slices"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -36,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -81,6 +90,138 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,resourceNames=cluster,verbs=get;list;watch
+
+func fetchTLSOpts(cfg *restclient.Config) []func(*tls.Config) {
+	var tlsOpts []func(*tls.Config)
+	bootstrapClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Info("Failed to create bootstrap client for TLS profile, using hardened defaults")
+		tlsOpts = append(tlsOpts, func(c *tls.Config) {
+			c.MinVersion = tls.VersionTLS12
+			c.NextProtos = []string{"h2", "http/1.1"}
+		})
+		return tlsOpts
+	}
+
+	apiServer := &unstructured.Unstructured{}
+	apiServer.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "APIServer",
+	})
+	if err := bootstrapClient.Get(context.Background(), client.ObjectKey{Name: "cluster"}, apiServer); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			setupLog.Info("TLS profile not available, using hardened defaults (non-OpenShift cluster)")
+			tlsOpts = append(tlsOpts, func(c *tls.Config) {
+				c.MinVersion = tls.VersionTLS12
+				c.CipherSuites = intermediateCiphers
+				c.NextProtos = []string{"h2", "http/1.1"}
+			})
+		} else {
+			setupLog.Error(err, "Failed to read APIServer TLS profile, operator cannot start without TLS policy")
+			os.Exit(1)
+		}
+	} else {
+		minVersion, ciphers := parseTLSProfile(apiServer)
+		if ciphers != nil && len(ciphers) == 0 {
+			setupLog.Error(nil, "Custom TLS profile specified ciphers but none are supported by Go, "+
+				"refusing to start with unrestricted ciphers")
+			os.Exit(1)
+		}
+		setupLog.Info("Applying cluster TLS profile", "minVersion", minVersion, "ciphers", len(ciphers))
+		tlsOpts = append(tlsOpts, func(c *tls.Config) {
+			c.MinVersion = minVersion
+			if len(ciphers) > 0 {
+				c.CipherSuites = ciphers
+			}
+			c.NextProtos = []string{"h2", "http/1.1"}
+		})
+	}
+	return tlsOpts
+}
+
+var tlsVersionMap = map[string]uint16{
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+var openSSLToGoCipher = map[string]uint16{
+	"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-AES128-SHA256":     tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"ECDHE-RSA-AES128-SHA256":       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"AES128-GCM-SHA256":             tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"AES256-GCM-SHA384":             tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"AES128-SHA256":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+}
+
+var intermediateMinVersion uint16 = tls.VersionTLS12
+var intermediateCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+func parseTLSProfile(apiServer *unstructured.Unstructured) (uint16, []uint16) {
+	profile, found, err := unstructured.NestedMap(apiServer.Object, "spec", "tlsSecurityProfile")
+	if err != nil {
+		setupLog.Error(err, "Failed to read tlsSecurityProfile from APIServer, using Intermediate defaults")
+		return intermediateMinVersion, intermediateCiphers
+	}
+	if !found || profile == nil {
+		return intermediateMinVersion, intermediateCiphers
+	}
+
+	profileType, _ := profile["type"].(string)
+	switch profileType {
+	case "Intermediate", "":
+		return intermediateMinVersion, intermediateCiphers
+	case "Custom":
+		custom, _, err := unstructured.NestedMap(profile, "custom")
+		if err != nil {
+			setupLog.Error(err, "Failed to read custom TLS profile, using Intermediate defaults")
+			return intermediateMinVersion, intermediateCiphers
+		}
+		if custom == nil {
+			setupLog.Info("Custom TLS profile type set but no custom block provided, using Intermediate defaults")
+			return intermediateMinVersion, intermediateCiphers
+		}
+		minVer, _ := custom["minTLSVersion"].(string)
+		minVersion := tlsVersionMap[minVer]
+		if minVersion == 0 {
+			minVersion = tls.VersionTLS12
+		}
+		cipherNames, _, err := unstructured.NestedStringSlice(custom, "ciphers")
+		if err != nil {
+			setupLog.Error(err, "Failed to read ciphers from custom TLS profile, proceeding without cipher restrictions")
+		}
+		ciphers := make([]uint16, 0, len(cipherNames))
+		for _, name := range cipherNames {
+			if id, ok := openSSLToGoCipher[name]; ok {
+				ciphers = append(ciphers, id)
+			} else {
+				setupLog.Info("Cipher from TLS profile not supported by Go, skipping", "cipher", name)
+			}
+		}
+		return minVersion, ciphers
+	case "Modern":
+		return tls.VersionTLS13, nil
+	case "Old":
+		return tls.VersionTLS12, nil
+	default:
+		setupLog.Info("Unrecognized TLS profile type, using Intermediate defaults", "profileType", profileType)
+		return intermediateMinVersion, intermediateCiphers
+	}
+}
+
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -107,9 +248,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	cfg := ctrl.GetConfigOrDie()
+	tlsOpts := fetchTLSOpts(cfg)
+
 	mgrOpts := ctrl.Options{
 		Scheme:                 scheme,
-		Metrics:                server.Options{BindAddress: metricsAddr},
+		Metrics:                server.Options{BindAddress: metricsAddr, TLSOpts: tlsOpts},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b7e9931f.trustyai.opendatahub.io",
@@ -129,6 +273,10 @@ func main() {
 				},
 			},
 		},
+		WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
+			Port:    9443,
+			TLSOpts: tlsOpts,
+		}),
 		// LeaderElectionReleaseOnCancel: true,
 	}
 

--- a/cmd/tls_test.go
+++ b/cmd/tls_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeAPIServer(profileType string, custom map[string]interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	spec := map[string]interface{}{}
+	if profileType != "" {
+		profile := map[string]interface{}{"type": profileType}
+		if custom != nil {
+			profile["custom"] = custom
+		}
+		spec["tlsSecurityProfile"] = profile
+	}
+	obj.Object["spec"] = spec
+	return obj
+}
+
+func TestParseTLSProfile(t *testing.T) {
+	t.Run("nil profile returns Intermediate defaults", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"spec": map[string]interface{}{},
+		}}
+		minVer, ciphers := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS12 {
+			t.Errorf("expected TLS 1.2, got %d", minVer)
+		}
+		if len(ciphers) != len(intermediateCiphers) {
+			t.Errorf("expected %d Intermediate ciphers, got %d", len(intermediateCiphers), len(ciphers))
+		}
+	})
+
+	t.Run("Intermediate returns Intermediate defaults", func(t *testing.T) {
+		obj := makeAPIServer("Intermediate", nil)
+		minVer, ciphers := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS12 {
+			t.Errorf("expected TLS 1.2, got %d", minVer)
+		}
+		if len(ciphers) != len(intermediateCiphers) {
+			t.Errorf("expected %d ciphers, got %d", len(intermediateCiphers), len(ciphers))
+		}
+	})
+
+	t.Run("Modern returns TLS 1.3 with nil ciphers", func(t *testing.T) {
+		obj := makeAPIServer("Modern", nil)
+		minVer, ciphers := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS13 {
+			t.Errorf("expected TLS 1.3, got %d", minVer)
+		}
+		if ciphers != nil {
+			t.Errorf("expected nil ciphers for Modern, got %v", ciphers)
+		}
+	})
+
+	t.Run("Old returns TLS 1.2 with nil ciphers", func(t *testing.T) {
+		obj := makeAPIServer("Old", nil)
+		minVer, ciphers := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS12 {
+			t.Errorf("expected TLS 1.2, got %d", minVer)
+		}
+		if ciphers != nil {
+			t.Errorf("expected nil ciphers for Old, got %v", ciphers)
+		}
+	})
+
+	t.Run("Custom with valid ciphers", func(t *testing.T) {
+		obj := makeAPIServer("Custom", map[string]interface{}{
+			"minTLSVersion": "VersionTLS12",
+			"ciphers":       []interface{}{"ECDHE-RSA-AES128-GCM-SHA256"},
+		})
+		minVer, ciphers := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS12 {
+			t.Errorf("expected TLS 1.2, got %d", minVer)
+		}
+		if len(ciphers) != 1 || ciphers[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+			t.Errorf("expected 1 cipher TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, got %v", ciphers)
+		}
+	})
+
+	t.Run("Custom with unsupported cipher logs and skips", func(t *testing.T) {
+		obj := makeAPIServer("Custom", map[string]interface{}{
+			"minTLSVersion": "VersionTLS12",
+			"ciphers":       []interface{}{"DHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES128-GCM-SHA256"},
+		})
+		_, ciphers := parseTLSProfile(obj)
+		if len(ciphers) != 1 {
+			t.Errorf("expected 1 cipher (DHE dropped), got %d", len(ciphers))
+		}
+		if len(ciphers) == 1 && ciphers[0] != tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 {
+			t.Errorf("expected TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, got %d", ciphers[0])
+		}
+	})
+
+	t.Run("Custom with nil custom block returns Intermediate", func(t *testing.T) {
+		obj := makeAPIServer("Custom", nil)
+		minVer, ciphers := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS12 {
+			t.Errorf("expected TLS 1.2, got %d", minVer)
+		}
+		if len(ciphers) != len(intermediateCiphers) {
+			t.Errorf("expected Intermediate ciphers, got %d", len(ciphers))
+		}
+	})
+
+	t.Run("Unknown profile type returns Intermediate", func(t *testing.T) {
+		obj := makeAPIServer("SomeFutureType", nil)
+		minVer, ciphers := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS12 {
+			t.Errorf("expected TLS 1.2, got %d", minVer)
+		}
+		if len(ciphers) != len(intermediateCiphers) {
+			t.Errorf("expected Intermediate ciphers, got %d", len(ciphers))
+		}
+	})
+
+	t.Run("Custom with TLS 1.3 minVersion", func(t *testing.T) {
+		obj := makeAPIServer("Custom", map[string]interface{}{
+			"minTLSVersion": "VersionTLS13",
+			"ciphers":       []interface{}{},
+		})
+		minVer, ciphers := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS13 {
+			t.Errorf("expected TLS 1.3, got %d", minVer)
+		}
+		if len(ciphers) != 0 {
+			t.Errorf("expected 0 ciphers, got %d", len(ciphers))
+		}
+	})
+
+	t.Run("Custom with unknown minTLSVersion falls back to TLS 1.2", func(t *testing.T) {
+		obj := makeAPIServer("Custom", map[string]interface{}{
+			"minTLSVersion": "VersionTLS10",
+			"ciphers":       []interface{}{"ECDHE-RSA-AES128-GCM-SHA256"},
+		})
+		minVer, _ := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS12 {
+			t.Errorf("expected TLS 1.2 fallback, got %d", minVer)
+		}
+	})
+
+	t.Run("Custom with all unsupported ciphers returns empty slice", func(t *testing.T) {
+		obj := makeAPIServer("Custom", map[string]interface{}{
+			"minTLSVersion": "VersionTLS12",
+			"ciphers":       []interface{}{"DHE-RSA-AES128-GCM-SHA256", "DHE-RSA-AES256-GCM-SHA384"},
+		})
+		minVer, ciphers := parseTLSProfile(obj)
+		if minVer != tls.VersionTLS12 {
+			t.Errorf("expected TLS 1.2, got %d", minVer)
+		}
+		if ciphers == nil {
+			t.Fatal("expected non-nil empty slice, got nil (fail-closed guard needs non-nil)")
+		}
+		if len(ciphers) != 0 {
+			t.Errorf("expected 0 ciphers (all unsupported dropped), got %d", len(ciphers))
+		}
+	})
+}
+
+func TestTLSVersionMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected uint16
+		found    bool
+	}{
+		{"TLS 1.2", "VersionTLS12", tls.VersionTLS12, true},
+		{"TLS 1.3", "VersionTLS13", tls.VersionTLS13, true},
+		{"unknown", "VersionTLS10", 0, false},
+		{"empty", "", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := tlsVersionMap[tt.input]
+			if ok != tt.found {
+				t.Errorf("tlsVersionMap[%q] found=%v, want %v", tt.input, ok, tt.found)
+			}
+			if got != tt.expected {
+				t.Errorf("tlsVersionMap[%q] = %d, want %d", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/config/rbac-base/kustomization.yaml
+++ b/config/rbac-base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - leader_election_role.yaml
   - leader_election_role_binding.yaml
   - service_account.yaml
+  - tls_profile_role.yaml

--- a/config/rbac-base/tls_profile_role.yaml
+++ b/config/rbac-base/tls_profile_role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tls-profile-reader
+rules:
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - apiservers
+    resourceNames:
+      - cluster
+    verbs:
+      - get
+      - list
+      - watch

--- a/policy/clusterrole.rego
+++ b/policy/clusterrole.rego
@@ -46,6 +46,9 @@ allowed_api_resources := {
 	["rbac.authorization.k8s.io", "roles"],
 	["rbac.authorization.k8s.io", "rolebindings"],
 
+	# --- openshift config ---
+	["config.openshift.io", "apiservers"],
+
 	# --- networking / routes ---
 	["networking.istio.io", "destinationrules"],
 	["networking.istio.io", "virtualservices"],


### PR DESCRIPTION
## Summary

- Read the cluster-wide TLS security profile from the `APIServer` CR (`config.openshift.io/cluster`) and apply it to the metrics and webhook servers
- On non-OpenShift clusters, falls back to hardened defaults (TLS 1.2 minimum, ALPN `h2`/`http1.1`)
- Uses unstructured access to avoid cascading dependency changes from adding `openshift/controller-runtime-common` to the older controller-runtime v0.17.0 dependency tree
- Handles all profile types: Intermediate (default, ECDHE-only ciphers), Modern (TLS 1.3), Old (TLS 1.2 floor), Custom (user-defined ciphers)
- Adds RBAC (`ClusterRole`) for reading `apiservers` resource scoped to `cluster`
- Includes 14 table-driven unit tests for `parseTLSProfile` and `tlsVersionMap`

Note: The 5 kube-rbac-proxy ConfigMap templates still have hardcoded cipher suites. Refactoring those to use the cluster TLS profile requires threading the profile data through the template context across 5+ controllers, which is better suited for a follow-up PR.

Ref: [RHOAIENG-61068](https://redhat.atlassian.net/browse/RHOAIENG-61068)

## Test plan

- [x] `go build ./cmd/...` passes
- [x] `go test ./cmd/... -v` passes (14 TLS tests + existing tests)
- [ ] Deploy on OpenShift cluster with Intermediate profile, verify metrics endpoint uses TLS 1.2 + ECDHE ciphers
- [ ] Deploy on vanilla K8s, verify fallback to TLS 1.2 defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatically derives and applies TLS configuration for both the controller-manager metrics server and the webhook server from the OpenShift APIServer TLS security profile.
  * Enables ALPN (`h2`, `http/1.1`) and adjusts TLS versions/ciphers per profile, with hardened intermediate defaults when the profile is missing, invalid, or unsupported.

* **Security / RBAC**
  * Added RBAC permission to read the OpenShift APIServer TLS security profile (`tls-profile-reader`).

* **Tests**
  * Added unit tests for TLS profile parsing, TLS version mapping, and cipher selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->