### PR TITLE
ci: sync main directly to stable, deprecate incubation sync

### DIFF
--- a/.github/workflows/sync-branch-incubation.yaml
+++ b/.github/workflows/sync-branch-incubation.yaml
@@ -1,8 +1,9 @@
-name: Sync branch incubation
+# DEPRECATED: main is now synced directly to stable by
+# sync-branch-stable.yaml. The automatic `push: main` trigger has been
+# removed; this workflow only runs when dispatched manually.
+name: Sync branch incubation (deprecated)
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   sync-branches:

--- a/.github/workflows/sync-branch-stable.yaml
+++ b/.github/workflows/sync-branch-stable.yaml
@@ -2,7 +2,7 @@ name: Sync branch stable
 on:
   push:
     branches:
-      - incubation
+      - main
 
 jobs:
   sync-branches:
@@ -17,7 +17,7 @@ jobs:
         uses: tretuna/sync-branches@1.4.0
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          FROM_BRANCH: "incubation"
+          FROM_BRANCH: "main"
           TO_BRANCH: "stable"
       - name: Add labels
         if: ${{ steps.pull.outputs.PULL_REQUEST_NUMBER != '' }}


### PR DESCRIPTION
The release flow no longer routes through the incubation branch. Sync PRs are now opened straight from main to stable.

- sync-branch-stable.yaml: trigger on push to main and set FROM_BRANCH to main (was incubation).
- sync-branch-incubation.yaml: drop the automatic push:main trigger in favour of workflow_dispatch, so the main -> incubation sync no longer runs on its own but can still be dispatched manually if needed. The job body is unchanged; the workflow name is suffixed "(deprecated)".

Resulting flow: upstream main -> midstream main (Pull bot + auto-merge) -> stable PR. Note that incubation will drift from main until it is merged manually or retired.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch synchronization to promote changes from `main` to `stable`.
  * Deprecated automatic synchronization to `incubation`; it can now be triggered manually when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->